### PR TITLE
index.html: fix a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 		<div class="container">
 			<header class="text-center text-light my-4">
                 <h1 class="mb-4">Be Rude 😤</i></h1>
-				<p class="mb-4 text-center">Be Rude 😤 lists all users who dont follow you back on GithHub</p>
+				<p class="mb-4 text-center">Be Rude 😤 lists all users who dont follow you back on GitHub</p>
 				<div class="input-group mb-3">
 					<input type="text" class=" username form-control" placeholder="Your Github Username" aria-label="GitHub's username" aria-describedby="button-addon2">
 					<div class="input-group-append">


### PR DESCRIPTION
fix a typo by renaming "GithHub" to "GitHub"